### PR TITLE
[BE] OAuth 로그인 구현

### DIFF
--- a/be/issue/build.gradle
+++ b/be/issue/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     // 패스워드 암호화
     implementation group: 'org.mindrot', name: 'jbcrypt', version: '0.4'
 
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 }
 

--- a/be/issue/src/main/java/codesquad/issueTracker/global/config/OauthConfig.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/global/config/OauthConfig.java
@@ -1,0 +1,25 @@
+package codesquad.issueTracker.global.config;
+
+import codesquad.issueTracker.jwt.domain.OAuthProperties;
+import codesquad.issueTracker.jwt.util.InMemoryProviderRepository;
+import codesquad.issueTracker.jwt.util.OauthAdapter;
+import codesquad.issueTracker.jwt.util.OauthProvider;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(OAuthProperties.class)
+@RequiredArgsConstructor
+public class OauthConfig {
+
+    private final OAuthProperties properties;
+
+    @Bean
+    public InMemoryProviderRepository inMemoryProviderRepository() {
+        Map<String, OauthProvider> providers = OauthAdapter.getOauthProviders(properties);
+        return new InMemoryProviderRepository(providers);
+    }
+}

--- a/be/issue/src/main/java/codesquad/issueTracker/global/config/WebConfig.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/global/config/WebConfig.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import codesquad.issueTracker.global.filter.AuthFilter;
-import codesquad.issueTracker.jwt.service.JwtProvider;
+import codesquad.issueTracker.jwt.util.JwtProvider;
 
 @Configuration
 public class WebConfig {

--- a/be/issue/src/main/java/codesquad/issueTracker/global/exception/ErrorCode.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/global/exception/ErrorCode.java
@@ -11,6 +11,11 @@ public enum ErrorCode implements StatusCode {
 
 	REQUEST_VALIDATION_FAIL(HttpStatus.BAD_REQUEST),
 
+	// -- [OAuth] -- //
+	NOT_SUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 로그인 방식입니다."),
+	GITHUB_LOGIN_USER(HttpStatus.BAD_REQUEST, "이미 깃허브로 로그인한 유저입니다"),
+
+
 	// -- [JWT] -- //
 	NOT_FOUND_REFRESH_TOKEN(HttpStatus.BAD_REQUEST,"해당하는 리프레시 토큰을 찾을 수 없습니다."),
 	MALFORMED_JWT_EXCEPTION(HttpStatus.UNAUTHORIZED, "잘못된 형식의 토큰입니다."),

--- a/be/issue/src/main/java/codesquad/issueTracker/global/filter/AuthFilter.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/global/filter/AuthFilter.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import codesquad.issueTracker.global.ApiResponse;
 import codesquad.issueTracker.global.exception.ErrorCode;
 import codesquad.issueTracker.global.exception.StatusCode;
-import codesquad.issueTracker.jwt.service.JwtProvider;
+import codesquad.issueTracker.jwt.util.JwtProvider;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.MalformedJwtException;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class AuthFilter implements Filter {
 
-	private final String[] whiteListUris = new String[] {"/", "/api/login", "/api/signup", "/api/login/oauth",
+	private final String[] whiteListUris = new String[] {"/", "/api/login", "/api/signup", "/api/login/**",
 		"/api/reissue/token"};
 
 	private final ObjectMapper objectMapper;

--- a/be/issue/src/main/java/codesquad/issueTracker/jwt/domain/OAuthProperties.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/jwt/domain/OAuthProperties.java
@@ -1,0 +1,32 @@
+package codesquad.issueTracker.jwt.domain;
+
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+
+@Getter
+@ConfigurationProperties(prefix = "oauth2")
+public class OAuthProperties {
+
+    private final Map<String, Client> client = new HashMap<>();
+    private final Map<String, Provider> provider = new HashMap();
+
+    @Getter
+    @Setter
+    public static class Client {
+        private String clientId;
+        private String clientSecret;
+        private String redirectUrl;
+    }
+
+    @Getter
+    @Setter
+    public static class Provider {
+        private String tokenUrl;
+        private String userInfoUrl;
+    }
+}

--- a/be/issue/src/main/java/codesquad/issueTracker/jwt/domain/OauthAttributes.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/jwt/domain/OauthAttributes.java
@@ -11,7 +11,7 @@ public enum OauthAttributes {
         public UserProfile of(Map<String, Object> attributes) {
             return UserProfile.builder()
                     .email((String) attributes.get("email"))
-                    .name((String) attributes.get("name"))
+                    .name((String) attributes.get("login"))
                     .imageUrl((String) attributes.get("avatar_url"))
                     .build();
         }

--- a/be/issue/src/main/java/codesquad/issueTracker/jwt/domain/OauthAttributes.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/jwt/domain/OauthAttributes.java
@@ -1,0 +1,35 @@
+package codesquad.issueTracker.jwt.domain;
+
+import codesquad.issueTracker.global.exception.CustomException;
+import codesquad.issueTracker.global.exception.ErrorCode;
+import java.util.Arrays;
+import java.util.Map;
+
+public enum OauthAttributes {
+    GITHUB("github") {
+        @Override
+        public UserProfile of(Map<String, Object> attributes) {
+            return UserProfile.builder()
+                    .email((String) attributes.get("email"))
+                    .name((String) attributes.get("name"))
+                    .imageUrl((String) attributes.get("avatar_url"))
+                    .build();
+        }
+    };
+
+    private final String providerName;
+
+    OauthAttributes(String name) {
+        this.providerName = name;
+    }
+
+    public static UserProfile extract(String providerName, Map<String, Object> attributes) {
+        return Arrays.stream(values())
+                .filter(provider -> providerName.equals(provider.providerName))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_SUPPORTED_PROVIDER))
+                .of(attributes);
+    }
+
+    public abstract UserProfile of(Map<String, Object> attributes);
+}

--- a/be/issue/src/main/java/codesquad/issueTracker/jwt/domain/UserProfile.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/jwt/domain/UserProfile.java
@@ -1,0 +1,30 @@
+package codesquad.issueTracker.jwt.domain;
+
+import codesquad.issueTracker.user.domain.LoginType;
+import codesquad.issueTracker.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserProfile {
+    private final String email;
+    private final String name;
+    private final String imageUrl;
+
+
+    @Builder
+    public UserProfile(String email, String name, String imageUrl) {
+        this.email = email;
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
+
+    public User toUser(String providerName) {
+        return User.builder()
+                .email(email)
+                .name(name)
+                .profileImg(imageUrl)
+                .loginType(LoginType.findByTypeString(providerName))
+                .build();
+    }
+}

--- a/be/issue/src/main/java/codesquad/issueTracker/jwt/dto/OauthTokenResponse.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/jwt/dto/OauthTokenResponse.java
@@ -1,0 +1,26 @@
+package codesquad.issueTracker.jwt.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OauthTokenResponse {
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    private String scope;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @Builder
+    public OauthTokenResponse(String accessToken, String scope, String tokenType) {
+        this.accessToken = accessToken;
+        this.scope = scope;
+        this.tokenType = tokenType;
+    }
+
+}

--- a/be/issue/src/main/java/codesquad/issueTracker/jwt/util/InMemoryProviderRepository.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/jwt/util/InMemoryProviderRepository.java
@@ -1,0 +1,13 @@
+package codesquad.issueTracker.jwt.util;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class InMemoryProviderRepository {
+    private final Map<String, OauthProvider> providers;
+
+    public OauthProvider findByProviderName(String name) {
+        return providers.get(name);
+    }
+}

--- a/be/issue/src/main/java/codesquad/issueTracker/jwt/util/JwtProvider.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/jwt/util/JwtProvider.java
@@ -1,4 +1,4 @@
-package codesquad.issueTracker.jwt.service;
+package codesquad.issueTracker.jwt.util;
 
 import java.util.Base64;
 import java.util.Date;
@@ -37,7 +37,7 @@ public class JwtProvider {
 
 	public Long getUserId(String token) {
 		Claims claims = getClaims(token);
-		return claims.get("id", Long.class);
+		return claims.get("userId", Long.class);
 	}
 
 	public Claims getClaims(String token) {

--- a/be/issue/src/main/java/codesquad/issueTracker/jwt/util/OauthAdapter.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/jwt/util/OauthAdapter.java
@@ -1,0 +1,19 @@
+package codesquad.issueTracker.jwt.util;
+
+import codesquad.issueTracker.jwt.domain.OAuthProperties;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class OauthAdapter {
+
+    public static Map<String, OauthProvider> getOauthProviders(OAuthProperties properties) {
+        Map<String, OauthProvider> oauthProvider = new HashMap<>();
+
+        properties.getClient().forEach(
+                (key, value) -> oauthProvider.put(
+                        key, new OauthProvider(value, properties.getProvider().get(key))));
+        return oauthProvider;
+    }
+}

--- a/be/issue/src/main/java/codesquad/issueTracker/jwt/util/OauthProvider.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/jwt/util/OauthProvider.java
@@ -1,0 +1,28 @@
+package codesquad.issueTracker.jwt.util;
+
+import codesquad.issueTracker.jwt.domain.OAuthProperties;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+public class OauthProvider {
+    private final String clientId;
+    private final String clientSecret;
+    private final String redirectUrl;
+    private final String tokenUrl;
+    private final String userInfoUrl;
+
+    public OauthProvider(OAuthProperties.Client client, OAuthProperties.Provider provider) {
+        this(client.getClientId(), client.getClientSecret(), client.getRedirectUrl(), provider.getTokenUrl(), provider.getUserInfoUrl());
+    }
+
+    @Builder
+    public OauthProvider(String clientId, String clientSecret, String redirectUrl, String tokenUrl, String userInfoUrl) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUrl = redirectUrl;
+        this.tokenUrl = tokenUrl;
+        this.userInfoUrl = userInfoUrl;
+    }
+}

--- a/be/issue/src/main/java/codesquad/issueTracker/user/controller/UserController.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/user/controller/UserController.java
@@ -5,9 +5,12 @@ import static codesquad.issueTracker.global.exception.SuccessCode.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import codesquad.issueTracker.global.ApiResponse;
@@ -48,5 +51,11 @@ public class UserController {
 	public ApiResponse<String> logout(HttpServletRequest request) {
 		userService.logout(request);
 		return ApiResponse.success(SUCCESS.getStatus(), SUCCESS.getMessage());
+	}
+
+	@GetMapping("/login/{provider}")
+	public ApiResponse<LoginResponseDto> oauthLogin(@PathVariable String provider, @RequestParam String code) {
+		LoginResponseDto loginResponseDto = userService.oauthLogin(provider, code);
+		return ApiResponse.success(SUCCESS.getStatus(), loginResponseDto);
 	}
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/user/domain/LoginType.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/user/domain/LoginType.java
@@ -9,8 +9,8 @@ import java.util.Arrays;
 @Getter
 public enum LoginType {
 
-    LOCAL("LOCAL"),
-    GITHUB("GITHUB");
+    LOCAL("local"),
+    GITHUB("github");
 
     private String type;
 

--- a/be/issue/src/main/java/codesquad/issueTracker/user/dto/LoginRequestDto.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/user/dto/LoginRequestDto.java
@@ -1,5 +1,6 @@
 package codesquad.issueTracker.user.dto;
 
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -8,7 +9,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @AllArgsConstructor
 public class LoginRequestDto {
+	@NotNull(message = "이메일을 입력해주세요")
 	private String email;
+	@NotNull(message = "패스워드를 입력해주세요")
 	private String password;
 
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/user/dto/SignUpRequestDto.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/user/dto/SignUpRequestDto.java
@@ -21,12 +21,13 @@ public class SignUpRequestDto {
     @Size(min = 6, max = 16, message = "아이디는 최소 6자리에서 16자리까지 입력할 수 있다.")
     private final String name;
 
-    public static User toEntity(SignUpRequestDto signUpRequestDto, String encodedPassword) {
+    public static User toEntity(SignUpRequestDto signUpRequestDto, String encodedPassword, String profileImg) {
         return User.builder()
                 .email(signUpRequestDto.getEmail())
                 .password(encodedPassword)
                 .name(signUpRequestDto.getName())
                 .loginType(LoginType.LOCAL)
+                .profileImg(profileImg)
                 .build();
     }
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/user/repository/UserRepository.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/user/repository/UserRepository.java
@@ -100,5 +100,12 @@ public class UserRepository {
 			.refreshToken(rs.getString("refresh_token"))
 			.build()
 	));
+
+
+	public Long updateUserLoginType(User existUser, User user) {
+		String sql = "UPDATE users SET login_type = :loginType WHERE id = :userId";
+		jdbcTemplate.update(sql,Map.of("loginType",user.getLoginType().getType(),"userId",existUser.getId()));
+		return existUser.getId();
+	}
 }
 

--- a/be/issue/src/main/java/codesquad/issueTracker/user/repository/UserRepository.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/user/repository/UserRepository.java
@@ -25,7 +25,7 @@ public class UserRepository {
 	}
 
 	public Long insert(User user) {
-		String sql = "INSERT INTO users (email,password,name, login_type) VALUES (:email,:password,:name,:loginType)";
+		String sql = "INSERT INTO users (email,password,name, login_type, profile_img) VALUES (:email,:password,:name,:loginType,:profileImg)";
 		KeyHolder keyHolder = new GeneratedKeyHolder();
 
 		MapSqlParameterSource params = new MapSqlParameterSource();
@@ -33,6 +33,7 @@ public class UserRepository {
 		params.addValue("password", user.getPassword());
 		params.addValue("name", user.getName());
 		params.addValue("loginType", user.getLoginType().getType());
+		params.addValue("profileImg", user.getProfileImg());
 
 		jdbcTemplate.update(sql, params, keyHolder);
 		return keyHolder.getKey().longValue();

--- a/be/issue/src/main/java/codesquad/issueTracker/user/service/UserService.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/user/service/UserService.java
@@ -1,9 +1,19 @@
 package codesquad.issueTracker.user.service;
 
+import codesquad.issueTracker.jwt.domain.OauthAttributes;
+import codesquad.issueTracker.jwt.domain.UserProfile;
+import codesquad.issueTracker.jwt.dto.OauthTokenResponse;
+import codesquad.issueTracker.jwt.util.InMemoryProviderRepository;
+import codesquad.issueTracker.jwt.util.OauthProvider;
+import codesquad.issueTracker.user.domain.LoginType;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Collections;
 
 import javax.servlet.http.HttpServletRequest;
 import org.mindrot.jbcrypt.BCrypt;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 
 import codesquad.issueTracker.global.exception.CustomException;
@@ -11,24 +21,29 @@ import codesquad.issueTracker.global.exception.ErrorCode;
 import codesquad.issueTracker.jwt.domain.Jwt;
 import codesquad.issueTracker.jwt.domain.Token;
 import codesquad.issueTracker.jwt.dto.RequestRefreshTokenDto;
-import codesquad.issueTracker.jwt.service.JwtProvider;
+import codesquad.issueTracker.jwt.util.JwtProvider;
 import codesquad.issueTracker.user.domain.User;
 import codesquad.issueTracker.user.dto.LoginRequestDto;
 import codesquad.issueTracker.user.dto.LoginResponseDto;
 import codesquad.issueTracker.user.dto.SignUpRequestDto;
 import codesquad.issueTracker.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @RequiredArgsConstructor
 @Service
 public class UserService {
 	private final UserRepository userRepository;
 	private final JwtProvider jwtProvider;
+	private final InMemoryProviderRepository inMemoryProviderRepository;
+	private final String DEFAULT_PROFILE_IMG = "https://upload.wikimedia.org/wikipedia/commons/1/17/Enhydra_lutris_face.jpg";
 
 	public Long save(SignUpRequestDto userSignUpRequestDto) {
 		validateDuplicatedEmail(userSignUpRequestDto);
 		String encodedPassword = BCrypt.hashpw(userSignUpRequestDto.getPassword(), BCrypt.gensalt());
-		User user = SignUpRequestDto.toEntity(userSignUpRequestDto, encodedPassword);
+		User user = SignUpRequestDto.toEntity(userSignUpRequestDto, encodedPassword, DEFAULT_PROFILE_IMG);
 		return userRepository.insert(user);
 	}
 
@@ -43,6 +58,9 @@ public class UserService {
 	public LoginResponseDto login(LoginRequestDto loginRequestDto) {
 		User user = userRepository.findByEmail(loginRequestDto.getEmail())
 				.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+		if(user.getPassword() == null){
+			throw new CustomException(ErrorCode.GITHUB_LOGIN_USER);
+		}
 		validateLoginUser(loginRequestDto, user);
 		Token token = userRepository.findTokenByUserId(user.getId()).orElse(null);
 		Jwt jwt = jwtProvider.createJwt(Map.of("userId", user.getId()));
@@ -73,7 +91,7 @@ public class UserService {
 
 	/**
 	 * 1. 만료된 리프레시 토큰이면 예외처리
-	 * 2. DB에 없는 리프레시 토큰이면 예
+	 * 2. DB에 없는 리프레시 토큰이면 예외처리
 	 */
 	public String reissueAccessToken(RequestRefreshTokenDto refreshTokenDto) {
 		jwtProvider.getClaims(refreshTokenDto.getRefreshToken());
@@ -87,5 +105,77 @@ public class UserService {
 		Long userId = Long.parseLong(String.valueOf(request.getAttribute("userId")));
 		userRepository.deleteTokenByUserId(userId)
 				.orElseThrow(() -> new CustomException(ErrorCode.DELETE_FAIL));
+	}
+
+	public LoginResponseDto oauthLogin(String providerName, String code) {
+		OauthProvider provider = inMemoryProviderRepository.findByProviderName(providerName);
+
+		OauthTokenResponse tokenResponse = getToken(code, provider);
+
+		User user = getUserProfile(providerName, tokenResponse, provider).toUser(providerName);
+		User existUser = userRepository.findByEmail(user.getEmail()).orElse(null);
+		Long userId;
+		if(existUser != null){
+			if(!existUser.getLoginType().getType().equals(providerName) && existUser.getLoginType() != LoginType.LOCAL) {
+				throw new CustomException(ErrorCode.ALREADY_EXIST_USER);
+			} else if (existUser.getLoginType().getType().equals(providerName)) {
+				userId = existUser.getId();
+//				userRepository.deleteTokenByUserId(userId);
+			} else {
+				userId = userRepository.updateUserLoginType(existUser, user);
+//				userRepository.deleteTokenByUserId(userId);
+			}
+		} else {
+			userId = userRepository.insert(user);
+		}
+
+		Jwt jwt = jwtProvider.createJwt(Map.of("userId", userId));
+		userRepository.insertRefreshToken(userId, jwt.getRefreshToken());
+
+		return LoginResponseDto.builder()
+				.userId(userId)
+				.accessToken(jwt.getAccessToken())
+				.refreshToken(jwt.getRefreshToken())
+				.profileImgUrl(user.getProfileImg())
+				.build();
+	}
+
+	private OauthTokenResponse getToken(String code, OauthProvider provider) {
+		return WebClient.create()
+				.post()
+				.uri(provider.getTokenUrl())
+				.headers(header -> {
+					header.setBasicAuth(provider.getClientId(), provider.getClientSecret());
+					header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+					header.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+					header.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
+				})
+				.bodyValue(tokenRequest(code,provider))
+				.retrieve()
+				.bodyToMono(OauthTokenResponse.class)
+				.block();
+	}
+
+	private MultiValueMap<String, String> tokenRequest(String code, OauthProvider provider) {
+		MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+		formData.add("code", code);
+		formData.add("grant_type", "authorization_code");
+		formData.add("redirect_uri", provider.getRedirectUrl());
+		return formData;
+	}
+
+	private UserProfile getUserProfile(String providerName, OauthTokenResponse tokenResponse, OauthProvider provider) {
+		Map<String, Object> userAttributes = getUserAttributes(provider, tokenResponse);
+		return OauthAttributes.extract(providerName, userAttributes);
+	}
+
+	private Map<String, Object> getUserAttributes(OauthProvider provider, OauthTokenResponse tokenResponse) {
+		return WebClient.create()
+				.get()
+				.uri(provider.getUserInfoUrl())
+				.headers(header -> header.setBearerAuth(tokenResponse.getAccessToken()))
+				.retrieve()
+				.bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+				.block();
 	}
 }

--- a/be/issue/src/test/java/codesquad/issueTracker/user/service/UserServiceTest.java
+++ b/be/issue/src/test/java/codesquad/issueTracker/user/service/UserServiceTest.java
@@ -17,7 +17,7 @@ import annotation.ServiceTest;
 import codesquad.issueTracker.global.exception.CustomException;
 import codesquad.issueTracker.jwt.domain.Jwt;
 import codesquad.issueTracker.jwt.domain.Token;
-import codesquad.issueTracker.jwt.service.JwtProvider;
+import codesquad.issueTracker.jwt.util.JwtProvider;
 import codesquad.issueTracker.user.domain.User;
 import codesquad.issueTracker.user.dto.LoginRequestDto;
 import codesquad.issueTracker.user.repository.UserRepository;


### PR DESCRIPTION
## What is this PR? 👓
OAuth 로그인 기능 구현


## To reviewers 👋

08/04
~1. 로컬로 회원가입 후 로컬로 로그인하면 refresh token이 생성이 돼서 제대로 동작~
~2. github으로 회원가입하고 로컬로 로그인 시도하면 password가 없어서 예외처리(이미 깃허브로 로그인한 사용자입니다)~  
~3. github으로 회원가입하고 로컬로 회원가입 시도하면 예외처리(이미 존재하는 사용자입니다)~
~4. 로컬로 회원가입 후 로컬로 로그인하고 github으로 로그인하면 제대로 연동됨~
  ~- 로컬과 깃허브 둘 다 로그인 가능~
~5. 로컬로 회원가입 후 github으로 로그인 시도하면 refresh token이 생성이 안됐어서 delete가 제대로 되지 않는 문제 발생~
 ~- 현재 delete 문을 주석처리하고 tokens 테이블에 계속 insert만 되게 해서 동작은 하게 만듦~

--- 
08/05
로그인 정책 변경 및 리팩토링 

- githubOAuthApp 은 깃허브 이메일이 private면 OAuth 의  https://api.github.com/user 의 요청으로 email 정보를 받아 올 수 없음 -> OAuthApp으로 후https://api.github.com/user/emails 를 통해 이메일이 private 인 유저의 이메일도 받아 올 수 있게 함 

- 로컬 로그인으로 가입 후 깃허브 로그인으로 로그인하면 로컬 회원을 깃허브 회원으로 업데이트 하려 했으나
로그인 하나에 너무 많은 기능이 들어가게 되고, 확장성을 고려 하면 많은 조건문이 필요하게 되어 
로컬로 생성한 계정은 로컬로그인만 깃허브로 로그인/회원가입 한 계정은 깃허브 로그인으로만 로그인이 가능하게 변경


 
