### PR TITLE
[BE] 댓글 테스트 코드 구현

### DIFF
--- a/be/issue/src/main/java/codesquad/issueTracker/comment/controller/CommentController.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/comment/controller/CommentController.java
@@ -36,12 +36,16 @@ public class CommentController {
 	}
 
 	@PostMapping("/issues/{issueId}/comments")
-	public ApiResponse<String> save(@PathVariable Long issueId,
-		@RequestBody CommentRequestDto commentRequestDto,
-		HttpServletRequest request) {
-		commentService.save(request, issueId, commentRequestDto);
+	public ApiResponse<String> save(@PathVariable Long issueId, @RequestBody CommentRequestDto commentRequestDto,
+								HttpServletRequest request) {
+		Long userId = findUserIdByHttpRequest(request);
+		commentService.save(userId, issueId, commentRequestDto);
 
 		return ApiResponse.success(SUCCESS.getStatus(), SUCCESS.getMessage());
+	}
+
+	private Long findUserIdByHttpRequest(HttpServletRequest request) {
+		return Long.parseLong(String.valueOf(request.getAttribute("userId")));
 	}
 
 	@PatchMapping("/issues/comments/{commentId}")

--- a/be/issue/src/main/java/codesquad/issueTracker/comment/dto/CommentRequestDto.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/comment/dto/CommentRequestDto.java
@@ -1,5 +1,6 @@
 package codesquad.issueTracker.comment.dto;
 
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CommentRequestDto {
 
+    @NotNull(message = "댓글 내용을 입력해주세요.")
     private String content;
 
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/comment/service/CommentService.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/comment/service/CommentService.java
@@ -23,8 +23,7 @@ public class CommentService {
     }
 
     @Transactional
-    public Long save(HttpServletRequest request, Long issueId, CommentRequestDto commentRequestDto) {
-        Long userId = Long.parseLong(String.valueOf(request.getAttribute("userId")));
+    public Long save(Long userId, Long issueId, CommentRequestDto commentRequestDto) {
         return commentRepository.create(userId, issueId, commentRequestDto)
                 .orElseThrow(() -> new CustomException(ErrorCode.DB_EXCEPTION));
     }

--- a/be/issue/src/main/java/codesquad/issueTracker/comment/service/CommentService.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/comment/service/CommentService.java
@@ -7,7 +7,6 @@ import codesquad.issueTracker.comment.repository.CommentRepository;
 import codesquad.issueTracker.global.exception.CustomException;
 import codesquad.issueTracker.global.exception.ErrorCode;
 import java.util.List;
-import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +24,7 @@ public class CommentService {
     @Transactional
     public Long save(Long userId, Long issueId, CommentRequestDto commentRequestDto) {
         return commentRepository.create(userId, issueId, commentRequestDto)
-                .orElseThrow(() -> new CustomException(ErrorCode.DB_EXCEPTION));
+                .orElseThrow(() -> new CustomException(ErrorCode.FAILED_CREATE_COMMENT));
     }
 
     @Transactional
@@ -33,7 +32,7 @@ public class CommentService {
         validateExistComment(commentId);
         validateCommentStatus(commentId);
         return commentRepository.update(commentId, commentRequestDto)
-                    .orElseThrow(() -> new CustomException(ErrorCode.DB_EXCEPTION));
+                .orElseThrow(() -> new CustomException(ErrorCode.FAILED_UPDATE_COMMENT));
     }
 
     @Transactional
@@ -41,7 +40,7 @@ public class CommentService {
         validateExistComment(commentId);
         validateCommentStatus(commentId);
         return commentRepository.deleteById(commentId)
-                .orElseThrow(() -> new CustomException(ErrorCode.DB_EXCEPTION));
+                .orElseThrow(() -> new CustomException(ErrorCode.FAILED_DELETE_COMMENT));
     }
 
     private Comment validateExistComment(Long commentId) {

--- a/be/issue/src/main/java/codesquad/issueTracker/global/exception/ErrorCode.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/global/exception/ErrorCode.java
@@ -11,10 +11,8 @@ import io.jsonwebtoken.security.SignatureException;
 
 public enum ErrorCode implements StatusCode {
 
-	REQUEST_VALIDATION_FAIL(HttpStatus.BAD_REQUEST),
-
 	// -- [Common] -- ]
-	DB_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "DB 서버 오류"),
+	REQUEST_VALIDATION_FAIL(HttpStatus.BAD_REQUEST),
 
 	// -- [OAuth] -- //
 	NOT_SUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 로그인 방식입니다."),
@@ -32,10 +30,14 @@ public enum ErrorCode implements StatusCode {
 	ALREADY_EXIST_USER(HttpStatus.BAD_REQUEST, "이미 존재하는 유저입니다."),
 	NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "해당하는 유저가 없습니다."),
 	FAILED_LOGIN_USER(HttpStatus.BAD_REQUEST, "로그인에 실패했습니다. 아이디, 비밀번호를 다시 입력해주세요. "),
+	FAILED_LOGOUT_USER(HttpStatus.SERVICE_UNAVAILABLE, "DB 서버 오류로 인해 사용자 로그아웃에 실패했습니다."),
 
 	// -- [Comment] -- //
 	NOT_EXIST_COMMENT(HttpStatus.BAD_REQUEST, "존재하지 않는 댓글입니다."),
 	ALREADY_DELETED_COMMENT(HttpStatus.BAD_REQUEST, "이미 삭제된 댓글입니다."),
+	FAILED_CREATE_COMMENT(HttpStatus.SERVICE_UNAVAILABLE, "DB 서버 오류로 인해 댓글 생성에 실패했습니다."),
+	FAILED_UPDATE_COMMENT(HttpStatus.SERVICE_UNAVAILABLE, "DB 서버 오류로 인해 댓글 수정에 실패했습니다."),
+	FAILED_DELETE_COMMENT(HttpStatus.SERVICE_UNAVAILABLE,"DB 서버 오류로 인해 댓글 삭제에 실패했습니다."),
 
 	// -- [Milestone] -- //
 	INVALIDATE_DATE(HttpStatus.BAD_REQUEST, "현재 날짜보다 이전 날짜 입니다."),
@@ -44,13 +46,10 @@ public enum ErrorCode implements StatusCode {
 	ILLEGAL_STATUS_MILESTONE(HttpStatus.BAD_REQUEST, "올바르지 않은 상태 입력 입니다."),
 
 	// -- [Label] -- //
-
 	LABEL_INSERT_FAILED(HttpStatus.BAD_REQUEST, "DB에서 라벨 생성에 실패했습니다."),
 	LABEL_UPDATE_FAILED(HttpStatus.BAD_REQUEST, "DB에서 라벨 수정에 실패했습니다."),
 	LABEL_DELETE_FAILED(HttpStatus.BAD_REQUEST, "DB에서 라벨 삭제에 실패했습니다"),
 	LABEL_FIND_FAILED(HttpStatus.BAD_REQUEST, "서버 오류로 라벨을 조회할 수 없습니다");
-
-
 
 
 	private HttpStatus status;

--- a/be/issue/src/main/java/codesquad/issueTracker/user/service/UserService.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/user/service/UserService.java
@@ -99,7 +99,7 @@ public class UserService {
 	public void logout(HttpServletRequest request) {
 		Long userId = Long.parseLong(String.valueOf(request.getAttribute("userId")));
 		userRepository.deleteTokenByUserId(userId)
-			.orElseThrow(() -> new CustomException(ErrorCode.DB_EXCEPTION));
+				.orElseThrow(() -> new CustomException(ErrorCode.FAILED_LOGOUT_USER));
 	}
 
 }

--- a/be/issue/src/test/java/codesquad/issueTracker/comment/controller/CommentControllerTest.java
+++ b/be/issue/src/test/java/codesquad/issueTracker/comment/controller/CommentControllerTest.java
@@ -1,0 +1,121 @@
+package codesquad.issueTracker.comment.controller;
+
+
+import static codesquad.issueTracker.global.exception.SuccessCode.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import annotation.ControllerTest;
+import codesquad.issueTracker.comment.dto.CommentRequestDto;
+import codesquad.issueTracker.comment.dto.CommentResponseDto;
+import codesquad.issueTracker.comment.fixture.CommentTestFixture;
+import codesquad.issueTracker.comment.service.CommentService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+
+@ControllerTest(CommentController.class)
+class CommentControllerTest extends CommentTestFixture {
+
+    private final Log log = LogFactory.getLog(CommentControllerTest.class);
+
+    private List<CommentResponseDto> commentResponseDtosFixture;
+    private CommentRequestDto commentRequestDtoFixture;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private CommentService commentService;
+
+    @BeforeEach
+    public void setUp() {
+        commentResponseDtosFixture = dummyCommentResponseDtos();
+        commentRequestDtoFixture = dummyCommentRequestDto(1);
+    }
+
+    @Test
+    @DisplayName("모든 댓글 목록들을 반환한다.")
+    public void getComments() throws Exception {
+        //given
+        given(commentService.getComments(any())).willReturn(commentResponseDtosFixture);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get("/api/issues/{issueId}/comments", 1L));
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(SUCCESS.getStatus().getReasonPhrase()))
+                .andExpect(jsonPath("$.message[0].id").value(commentResponseDtosFixture.get(0).getId()))
+                .andExpect(jsonPath("$.message[0].createdAt").value(commentResponseDtosFixture.get(0).getCreatedAt().toString()))
+                .andExpect(jsonPath("$.message[0].content").value(commentResponseDtosFixture.get(0).getContent()))
+                .andExpect(jsonPath("$.message[0].writer.name").value(commentResponseDtosFixture.get(0).getWriter().getName()))
+                .andExpect(jsonPath("$.message[0].writer.profileImg").value(commentResponseDtosFixture.get(0).getWriter().getProfileImg()));
+    }
+
+    @Test
+    @DisplayName("이슈 댓글을 작성한다.")
+    public void save() throws Exception {
+        //given
+        given(commentService.save(any(), any(), any())).willReturn(1L);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(post("/api/issues/{issueId}/comments", 1L)
+                .content(objectMapper.writeValueAsString(commentRequestDtoFixture))
+                .contentType(MediaType.APPLICATION_JSON)
+                .requestAttr("userId", 1L));
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(SUCCESS.getStatus().getReasonPhrase()))
+                .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()));
+    }
+
+    @Test
+    @DisplayName("이슈 댓글을 수정한다.")
+    public void modify() throws Exception {
+        //given
+        given(commentService.modify(any(), any())).willReturn(1L);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(patch("/api/issues/comments/{commentId}", 1L)
+                .content(objectMapper.writeValueAsString(commentRequestDtoFixture))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(SUCCESS.getStatus().getReasonPhrase()))
+                .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()));
+    }
+
+    @Test
+    @DisplayName("이슈 댓글을 삭제한다.")
+    public void delete() throws Exception {
+        //given
+        given(commentService.delete(any())).willReturn(1L);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.delete("/api/issues/comments/{commentId}", 1L));
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(SUCCESS.getStatus().getReasonPhrase()))
+                .andExpect(jsonPath("$.message").value(SUCCESS.getMessage()));
+    }
+}

--- a/be/issue/src/test/java/codesquad/issueTracker/comment/fixture/CommentTestFixture.java
+++ b/be/issue/src/test/java/codesquad/issueTracker/comment/fixture/CommentTestFixture.java
@@ -51,5 +51,10 @@ public abstract class CommentTestFixture {
     public CommentRequestDto dummyCommentRequestDto(int num) {
         return new CommentRequestDto("comment test" + num);
     }
-    
+
+    public List<CommentRequestDto> dummyCommentRequestDtos() {
+        return IntStream.range(1, 4)
+                .mapToObj(this::dummyCommentRequestDto)
+                .collect(Collectors.toList());
+    }
 }

--- a/be/issue/src/test/java/codesquad/issueTracker/comment/fixture/CommentTestFixture.java
+++ b/be/issue/src/test/java/codesquad/issueTracker/comment/fixture/CommentTestFixture.java
@@ -1,0 +1,55 @@
+package codesquad.issueTracker.comment.fixture;
+
+import codesquad.issueTracker.comment.domain.Comment;
+import codesquad.issueTracker.comment.dto.CommentRequestDto;
+import codesquad.issueTracker.comment.dto.CommentResponseDto;
+import codesquad.issueTracker.comment.vo.CommentUserVo;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public abstract class CommentTestFixture {
+    public List<CommentResponseDto> dummyCommentResponseDtos() {
+        return IntStream.range(1, 4)
+                .mapToObj(this::makeCommentResponses)
+                .collect(Collectors.toList());
+    }
+
+    private CommentResponseDto makeCommentResponses(int num) {
+        Comment comment = dummyComment(num);
+        CommentUserVo commentUserVo = makeCommentUser();
+
+        return CommentResponseDto.builder()
+                .id((long) num)
+                .content(comment.getContent())
+                .writer(commentUserVo)
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+
+    public Comment dummyComment(int num) {
+        return Comment.builder()
+                .issueId(1L)
+                .userId(1L)
+                .content("comment test" + num)
+                .createdAt(dummyLocalDateTime())
+                .build();
+    }
+
+    private LocalDateTime dummyLocalDateTime() {
+        return LocalDateTime.of(2023, 8, 12, 7, 23, 10);
+    }
+
+    private CommentUserVo makeCommentUser() {
+        return CommentUserVo.builder()
+                .name("sio")
+                .profileImg("http://image.png")
+                .build();
+    }
+
+    public CommentRequestDto dummyCommentRequestDto(int num) {
+        return new CommentRequestDto("comment test" + num);
+    }
+    
+}

--- a/be/issue/src/test/java/codesquad/issueTracker/comment/repository/CommentRepositoryTest.java
+++ b/be/issue/src/test/java/codesquad/issueTracker/comment/repository/CommentRepositoryTest.java
@@ -1,0 +1,149 @@
+package codesquad.issueTracker.comment.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import annotation.RepositoryTest;
+import codesquad.issueTracker.comment.domain.Comment;
+import codesquad.issueTracker.comment.dto.CommentRequestDto;
+import codesquad.issueTracker.comment.dto.CommentResponseDto;
+import codesquad.issueTracker.comment.fixture.CommentTestFixture;
+import codesquad.issueTracker.user.domain.LoginType;
+import codesquad.issueTracker.user.domain.User;
+import codesquad.issueTracker.user.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+
+@RepositoryTest
+class CommentRepositoryTest extends CommentTestFixture {
+
+    private CommentRequestDto commentRequestDtoFixture1;
+    private CommentRequestDto commentRequestDtoFixture2;
+    private List<CommentRequestDto> commentRequestDtosFixture;
+    private List<CommentResponseDto> commentResponseDtosFixture;
+
+    private UserRepository userRepository;
+    private CommentRepository commentRepository;
+
+    @Autowired
+    public CommentRepositoryTest(JdbcTemplate jdbcTemplate) {
+        this.commentRepository = new CommentRepository(jdbcTemplate);
+        this.userRepository = new UserRepository(jdbcTemplate);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        commentRequestDtoFixture1 = dummyCommentRequestDto(1);
+        commentRequestDtoFixture2 = dummyCommentRequestDto(2);
+        commentRequestDtosFixture = dummyCommentRequestDtos();
+        commentResponseDtosFixture = dummyCommentResponseDtos();
+    }
+
+    @Test
+    @DisplayName("DB에 댓글 생성 데이터가 제대로 들어간다.")
+    public void create() throws Exception {
+        //given
+        Long userId = 1L;
+        Long issueId = 1L;
+
+        //when
+        Long actual = commentRepository.create(userId, issueId, commentRequestDtoFixture1).get();
+
+        //then
+        assertThat(actual).isEqualTo(1L);
+    }
+    @Test
+    @DisplayName("이슈 id에 해당하는 댓글 목록을 반환할 수 있다.")
+    public void findComments() throws Exception {
+        //given
+        Long userId = 1L;
+        Long issueId = 1L;
+
+        User user = User.builder()
+                .id(1L)
+                .name("sio")
+                .email("sio@gmail.com")
+                .profileImg("http://image.png")
+                .loginType(LoginType.GITHUB)
+                .build();
+
+        userRepository.insert(user);
+
+        for (CommentRequestDto commentRequestDto : commentRequestDtosFixture) {
+            commentRepository.create(userId, issueId, commentRequestDto);
+        }
+        //when
+        List<CommentResponseDto> actual = commentRepository.findByIssueId(issueId);
+
+        //then
+        assertThat(actual.get(0).getId()).isEqualTo(commentResponseDtosFixture.get(0).getId());
+    }
+
+    @Test
+    @DisplayName("DB에 댓글 수정 데이터가 제대로 반영된다.")
+    public void update() throws Exception {
+        //given
+        Long userId = 1L;
+        Long issueId = 1L;
+        commentRepository.create(userId, issueId, commentRequestDtoFixture1);
+
+        //when
+        Long updatedId = commentRepository.update(userId, commentRequestDtoFixture2).get();
+        Comment actual = commentRepository.findById(updatedId).get();
+
+        //then
+        assertThat(actual.getContent()).isEqualTo(commentRequestDtoFixture2.getContent());
+    }
+
+    @Test
+    @DisplayName("DB에 댓글 삭제가 제대로 반영된다.")
+    public void delete() throws Exception {
+        //given
+        Long userId = 1L;
+        Long issueId = 1L;
+        Long commentId = commentRepository.create(userId, issueId, commentRequestDtoFixture1).get();
+
+        //when
+        Long deletedId = commentRepository.deleteById(commentId).get();
+        Optional<Comment> actual = commentRepository.findExistCommentById(deletedId);
+
+        //then
+        assertThat(actual.isPresent()).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("findById 동작 테스트")
+    public void findById() throws Exception {
+        //given
+        Long userId = 1L;
+        Long issueId = 1L;
+        Long commentId = commentRepository.create(userId, issueId, commentRequestDtoFixture1).get();
+
+        //when
+        Comment actual = commentRepository.findById(commentId).get();
+
+        //then
+        assertThat(actual.getId()).isEqualTo(commentId);
+    }
+
+    @Test
+    @DisplayName("findExistCommentById 동작 테스트")
+    public void findExistCommentById() throws Exception {
+        //given
+        Long userId = 1L;
+        Long issueId = 1L;
+        Long commentId = commentRepository.create(userId, issueId, commentRequestDtoFixture1).get();
+        commentRepository.deleteById(commentId);
+
+        //when
+        Optional<Comment> actual = commentRepository.findExistCommentById(commentId);
+
+        //then
+        assertThat(actual.isPresent()).isEqualTo(false);
+    }
+}

--- a/be/issue/src/test/java/codesquad/issueTracker/comment/service/CommentServiceTest.java
+++ b/be/issue/src/test/java/codesquad/issueTracker/comment/service/CommentServiceTest.java
@@ -1,0 +1,218 @@
+package codesquad.issueTracker.comment.service;
+
+import static codesquad.issueTracker.global.exception.ErrorCode.*;
+import static codesquad.issueTracker.global.exception.ErrorCode.FAILED_CREATE_COMMENT;
+import static codesquad.issueTracker.global.exception.ErrorCode.FAILED_DELETE_COMMENT;
+import static codesquad.issueTracker.global.exception.ErrorCode.FAILED_UPDATE_COMMENT;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import annotation.ServiceTest;
+import codesquad.issueTracker.comment.domain.Comment;
+import codesquad.issueTracker.comment.dto.CommentRequestDto;
+import codesquad.issueTracker.comment.dto.CommentResponseDto;
+import codesquad.issueTracker.comment.fixture.CommentTestFixture;
+import codesquad.issueTracker.comment.repository.CommentRepository;
+import codesquad.issueTracker.global.exception.CustomException;
+import java.util.List;
+import java.util.Optional;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+@ServiceTest
+class CommentServiceTest extends CommentTestFixture {
+
+    private final Log log = LogFactory.getLog(CommentServiceTest.class);
+    private List<CommentResponseDto> commentResponseDtosFixture;
+    private CommentRequestDto commentRequestDtoFixture;
+    private Comment commentFixture;
+
+    @InjectMocks
+    CommentService commentService;
+
+    @Mock
+    CommentRepository commentRepository;
+
+    @BeforeEach
+    public void setUp() {
+        commentResponseDtosFixture = dummyCommentResponseDtos();
+        commentRequestDtoFixture = dummyCommentRequestDto(1);
+        commentFixture = dummyComment(1);
+    }
+
+    @Test
+    @DisplayName("댓글 목록 조회에 성공한다.")
+    public void getComments() throws Exception {
+        //given
+        given(commentRepository.findByIssueId(1L)).willReturn(commentResponseDtosFixture);
+
+        //when
+        List<CommentResponseDto> actual = commentService.getComments(1L);
+
+        //then
+        assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(commentResponseDtosFixture);
+    }
+
+    @Test
+    @DisplayName("댓글 생성에 성공한다.")
+    public void save_success() throws Exception {
+        //given
+        given(commentRepository.create(any(), any(), any())).willReturn(Optional.ofNullable(1L));
+
+        //when
+        Long actual = commentService.save(1L, 1L, commentRequestDtoFixture);
+
+        //then
+        assertThat(actual).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("DB 서버 오류로 인해 댓글 생성에 실패한다.")
+    public void save_fail() throws Exception {
+        //given
+        given(commentRepository.create(any(), any(), any())).willReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> commentService.save(1L, 1L, commentRequestDtoFixture))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> {
+                    CustomException customException = (CustomException) e;
+                    assertThat(customException.getStatusCode()).isEqualTo(FAILED_CREATE_COMMENT);
+                });
+    }
+
+    @Test
+    @DisplayName("댓글 수정에 성공한다.")
+    public void update_success() throws Exception {
+        //given
+        given(commentRepository.findExistCommentById(1L)).willReturn(Optional.ofNullable(commentFixture));
+        given(commentRepository.findById(1L)).willReturn(Optional.ofNullable(commentFixture));
+        given(commentRepository.update(any(), any())).willReturn(Optional.ofNullable(1L));
+
+        //when
+        Long actual = commentService.modify(1L, commentRequestDtoFixture);
+
+        //then
+        assertThat(actual).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("DB 서버 오류로 인해 댓글 수정에 실패한다.")
+    public void update_fail() throws Exception {
+        //given
+        given(commentRepository.findExistCommentById(1L)).willReturn(Optional.ofNullable(commentFixture));
+        given(commentRepository.findById(1L)).willReturn(Optional.ofNullable(commentFixture));
+        given(commentRepository.update(any(), any())).willReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> commentService.modify(1L, commentRequestDtoFixture))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> {
+                    CustomException customException = (CustomException) e;
+                    assertThat(customException.getStatusCode()).isEqualTo(FAILED_UPDATE_COMMENT);
+                });
+    }
+
+    @Test
+    @DisplayName("이미 삭제된 상태인 댓글일 경우 댓글 수정에 실패한다.")
+    public void update_fail_already_deleted() throws Exception {
+        //given
+        given(commentRepository.findById(1L)).willReturn(Optional.ofNullable(commentFixture));
+        given(commentRepository.findExistCommentById(any())).willReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> commentService.modify(1L, commentRequestDtoFixture))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> {
+                    CustomException customException = (CustomException) e;
+                    assertThat(customException.getStatusCode()).isEqualTo(ALREADY_DELETED_COMMENT);
+                });
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글인 경우 댓글 수정에 실패한다.")
+    public void update_fail_not_exist() throws Exception {
+        //given
+        given(commentRepository.findById(1L)).willReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> commentService.modify(1L, commentRequestDtoFixture))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> {
+                    CustomException customException = (CustomException) e;
+                    assertThat(customException.getStatusCode()).isEqualTo(NOT_EXIST_COMMENT);
+                });
+    }
+
+    @Test
+    @DisplayName("댓글 삭제에 성공한다.")
+    public void delete_success() throws Exception {
+        //given
+        given(commentRepository.findExistCommentById(1L)).willReturn(Optional.ofNullable(commentFixture));
+        given(commentRepository.findById(1L)).willReturn(Optional.ofNullable(commentFixture));
+        given(commentRepository.deleteById(any())).willReturn(Optional.of(1L));
+
+        //when
+        Long actual = commentService.delete(1L);
+
+        //then
+        assertThat(actual).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("DB 서버 오류로 인해 댓글 삭제에 실패한다.")
+    public void delete_fail() throws Exception {
+        //given
+        given(commentRepository.findExistCommentById(1L)).willReturn(Optional.ofNullable(commentFixture));
+        given(commentRepository.findById(1L)).willReturn(Optional.ofNullable(commentFixture));
+        given(commentRepository.deleteById(any())).willReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> commentService.delete(1L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> {
+                    CustomException customException = (CustomException) e;
+                    assertThat(customException.getStatusCode()).isEqualTo(FAILED_DELETE_COMMENT);
+                });
+    }
+
+    @Test
+    @DisplayName("이미 댓글이 삭제된 상태인 경우 댓글 삭제에 실패한다.")
+    public void delete_fail_already_deleted() throws Exception {
+        //given
+        given(commentRepository.findById(1L)).willReturn(Optional.ofNullable(commentFixture));
+        given(commentRepository.findExistCommentById(any())).willReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> commentService.delete(1L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> {
+                    CustomException customException = (CustomException) e;
+                    assertThat(customException.getStatusCode()).isEqualTo(ALREADY_DELETED_COMMENT);
+                });
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글인 경우 댓글 삭제에 실패한다.")
+    public void delete_fail_not_exist() throws Exception {
+        //given
+        given(commentRepository.findById(1L)).willReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> commentService.delete(1L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> {
+                    CustomException customException = (CustomException) e;
+                    assertThat(customException.getStatusCode()).isEqualTo(NOT_EXIST_COMMENT);
+                });
+    }
+
+}


### PR DESCRIPTION
## What is this PR? 👓
- [x] 댓글 컨트롤러 단위 테스트
- [x] 댓글 서비스 단위 테스트
- [x] 댓글 레포지토리 단위 테스트
- [x] 리뷰어 피드백 반영
   - userId 찾는 부분 컨트롤러로 이동
   - CommentRequestDto에 validation 추가
   - DB_EXCEPTION 분리 


## To reviewers 👋
다시 커밋했습니다~!    
fixture 추상 클래스를 만들어서 여러 클래스에 상속 받아 사용해봤습니다.
