### PR TITLE
[BE] 이슈 조회 API 구현(이슈 목록 조회 API 제외)

### DIFF
--- a/be/issue/src/main/java/codesquad/issueTracker/comment/repository/CommentRepository.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/comment/repository/CommentRepository.java
@@ -108,6 +108,6 @@ public class CommentRepository {
 		.userId(rs.getLong("user_id"))
 		.issueId(rs.getLong("issue_id"))
 		.content(rs.getString("content"))
-		.createdAt(rs.getTimestamp("created_At").toLocalDateTime())
+		.createdAt(rs.getTimestamp("created_at").toLocalDateTime())
 		.build());
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/global/exception/ErrorCode.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/global/exception/ErrorCode.java
@@ -53,7 +53,9 @@ public enum ErrorCode implements StatusCode {
 
 
 	// -- [Issue] -- //
-	DUPLICATE_OBJECT_FOUND(HttpStatus.BAD_REQUEST, "중복된 항목 선택입니다.");
+	DUPLICATE_OBJECT_FOUND(HttpStatus.BAD_REQUEST, "중복된 항목 선택입니다."),
+	NOT_EXIST_ISSUE(HttpStatus.BAD_REQUEST, "존재하지 않는 이슈입니다."),
+	ALREADY_DELETED_ISSUE(HttpStatus.BAD_REQUEST, "이미 삭제된 이슈입니다.");
 
 
 	private HttpStatus status;

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/controller/IssueController.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/controller/IssueController.java
@@ -3,6 +3,7 @@ package codesquad.issueTracker.issue.controller;
 import static codesquad.issueTracker.global.exception.SuccessCode.*;
 
 import codesquad.issueTracker.issue.dto.IssueLabelResponseDto;
+import codesquad.issueTracker.issue.dto.IssueMilestoneResponseDto;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
@@ -37,5 +38,11 @@ public class IssueController {
 	public ApiResponse<List<IssueLabelResponseDto>> getIssueLabels() {
 		List<IssueLabelResponseDto> labels = issueService.getIssueLabels();
 		return ApiResponse.success(SUCCESS.getStatus(), labels);
+	}
+
+	@GetMapping("/issues/milestones")
+	public ApiResponse<List<IssueMilestoneResponseDto>> getIssueMilestones() {
+		List<IssueMilestoneResponseDto> milestones = issueService.getIssueMilestones();
+		return ApiResponse.success(SUCCESS.getStatus(), milestones);
 	}
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/controller/IssueController.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/controller/IssueController.java
@@ -61,4 +61,9 @@ public class IssueController {
 		return ApiResponse.success(SUCCESS.getStatus(), issueResponseDto);
 	}
 
+	@GetMapping("/issues/{issueId}/options")
+	public ApiResponse<IssueOptionResponseDto> getIssueOptions(@PathVariable Long issueId) {
+		IssueOptionResponseDto issueOptionResponseDto = issueService.getIssueOptions(issueId);
+		return ApiResponse.success(SUCCESS.getStatus(), issueOptionResponseDto);
+	}
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/controller/IssueController.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/controller/IssueController.java
@@ -4,6 +4,7 @@ import static codesquad.issueTracker.global.exception.SuccessCode.*;
 
 import codesquad.issueTracker.issue.dto.IssueLabelResponseDto;
 import codesquad.issueTracker.issue.dto.IssueMilestoneResponseDto;
+import codesquad.issueTracker.issue.dto.IssueOptionResponseDto;
 import codesquad.issueTracker.issue.dto.IssueResponseDto;
 import codesquad.issueTracker.issue.dto.IssueUserResponseDto;
 import java.util.List;

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/controller/IssueController.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/controller/IssueController.java
@@ -2,9 +2,12 @@ package codesquad.issueTracker.issue.controller;
 
 import static codesquad.issueTracker.global.exception.SuccessCode.*;
 
+import codesquad.issueTracker.issue.dto.IssueLabelResponseDto;
+import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,9 +27,15 @@ public class IssueController {
 
 	@PostMapping("/issues")
 	public ApiResponse<String> postIssues(@Valid @RequestBody IssueWriteRequestDto request,
-		HttpServletRequest httpServletRequest) {
+										  HttpServletRequest httpServletRequest) {
 		Long id = Long.parseLong(String.valueOf(httpServletRequest.getAttribute("userId")));
 		issueService.save(request, id);
 		return ApiResponse.success(SUCCESS.getStatus(), SUCCESS.getMessage());
+	}
+
+	@GetMapping("/issues/labels")
+	public ApiResponse<List<IssueLabelResponseDto>> getIssueLabels() {
+		List<IssueLabelResponseDto> labels = issueService.getIssueLabels();
+		return ApiResponse.success(SUCCESS.getStatus(), labels);
 	}
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/controller/IssueController.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/controller/IssueController.java
@@ -4,12 +4,14 @@ import static codesquad.issueTracker.global.exception.SuccessCode.*;
 
 import codesquad.issueTracker.issue.dto.IssueLabelResponseDto;
 import codesquad.issueTracker.issue.dto.IssueMilestoneResponseDto;
+import codesquad.issueTracker.issue.dto.IssueResponseDto;
 import codesquad.issueTracker.issue.dto.IssueUserResponseDto;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -51,6 +53,12 @@ public class IssueController {
 	public ApiResponse<List<IssueUserResponseDto>> getIssueUsers() {
 		List<IssueUserResponseDto> participants = issueService.getIssueUsers();
 		return ApiResponse.success(SUCCESS.getStatus(), participants);
+	}
+
+	@GetMapping("/issues/{issueId}")
+	public ApiResponse<IssueResponseDto> getIssue(@PathVariable Long issueId) {
+		IssueResponseDto issueResponseDto = issueService.getIssueById(issueId);
+		return ApiResponse.success(SUCCESS.getStatus(), issueResponseDto);
 	}
 
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/controller/IssueController.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/controller/IssueController.java
@@ -4,6 +4,7 @@ import static codesquad.issueTracker.global.exception.SuccessCode.*;
 
 import codesquad.issueTracker.issue.dto.IssueLabelResponseDto;
 import codesquad.issueTracker.issue.dto.IssueMilestoneResponseDto;
+import codesquad.issueTracker.issue.dto.IssueUserResponseDto;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
@@ -45,4 +46,11 @@ public class IssueController {
 		List<IssueMilestoneResponseDto> milestones = issueService.getIssueMilestones();
 		return ApiResponse.success(SUCCESS.getStatus(), milestones);
 	}
+
+	@GetMapping("/issues/participants")
+	public ApiResponse<List<IssueUserResponseDto>> getIssueUsers() {
+		List<IssueUserResponseDto> participants = issueService.getIssueUsers();
+		return ApiResponse.success(SUCCESS.getStatus(), participants);
+	}
+
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/controller/IssueOptionResponseDto.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/controller/IssueOptionResponseDto.java
@@ -1,0 +1,39 @@
+package codesquad.issueTracker.issue.controller;
+
+import codesquad.issueTracker.issue.vo.IssueLabelVo;
+import codesquad.issueTracker.issue.vo.IssueMilestoneVo;
+import codesquad.issueTracker.issue.vo.AssigneeVo;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class IssueOptionResponseDto {
+
+    private List<AssigneeVo> assignees;
+    private List<IssueLabelVo> labels;
+    private IssueMilestoneVo milestone;
+
+    @Builder
+    public IssueOptionResponseDto(List<AssigneeVo> assignees, List<IssueLabelVo> labels, IssueMilestoneVo milestone) {
+        this.assignees = assignees;
+        this.labels = labels;
+        this.milestone = milestone;
+    }
+
+    public static IssueOptionResponseDto of(List<AssigneeVo> assignees, List<IssueLabelVo> labels, IssueMilestoneVo milestone) {
+        if (milestone.getId() == null) {
+            return IssueOptionResponseDto.builder()
+                    .assignees(assignees)
+                    .labels(labels)
+                    .build();
+        }
+
+        return IssueOptionResponseDto.builder()
+                .assignees(assignees)
+                .labels(labels)
+                .milestone(milestone)
+                .build();
+    }
+
+}

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/dto/IssueLabelResponseDto.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/dto/IssueLabelResponseDto.java
@@ -1,0 +1,30 @@
+package codesquad.issueTracker.issue.dto;
+
+import codesquad.issueTracker.label.vo.LabelVo;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class IssueLabelResponseDto {
+    private Long id;
+    private String name;
+    private String backgroundColor;
+    private String textColor;
+
+    @Builder
+    public IssueLabelResponseDto(Long id, String name, String backgroundColor, String textColor) {
+        this.id = id;
+        this.name = name;
+        this.backgroundColor = backgroundColor;
+        this.textColor = textColor;
+    }
+
+    public static IssueLabelResponseDto from(LabelVo label) {
+        return IssueLabelResponseDto.builder()
+                .id(label.getId())
+                .name(label.getName())
+                .backgroundColor(label.getBackgroundColor())
+                .textColor(label.getTextColor())
+                .build();
+    }
+}

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/dto/IssueMilestoneResponseDto.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/dto/IssueMilestoneResponseDto.java
@@ -1,0 +1,24 @@
+package codesquad.issueTracker.issue.dto;
+
+import codesquad.issueTracker.milestone.vo.MilestoneVo;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class IssueMilestoneResponseDto {
+    private Long id;
+    private String name;
+
+    @Builder
+    public IssueMilestoneResponseDto(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public static IssueMilestoneResponseDto from(MilestoneVo milestoneVo) {
+        return builder()
+                .id(milestoneVo.getId())
+                .name(milestoneVo.getName())
+                .build();
+    }
+}

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/dto/IssueOptionResponseDto.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/dto/IssueOptionResponseDto.java
@@ -1,4 +1,4 @@
-package codesquad.issueTracker.issue.controller;
+package codesquad.issueTracker.issue.dto;
 
 import codesquad.issueTracker.issue.vo.IssueLabelVo;
 import codesquad.issueTracker.issue.vo.IssueMilestoneVo;

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/dto/IssueResponseDto.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/dto/IssueResponseDto.java
@@ -1,0 +1,35 @@
+package codesquad.issueTracker.issue.dto;
+
+import codesquad.issueTracker.issue.domain.Issue;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class IssueResponseDto {
+
+    private Long id;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+    private boolean isClose;
+
+    @Builder
+    public IssueResponseDto(Long id, String title, String content, LocalDateTime createdAt, boolean isClose) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.isClose = isClose;
+    }
+
+    public static IssueResponseDto from(Issue issue) {
+        return IssueResponseDto.builder()
+                .id(issue.getId())
+                .title(issue.getTitle())
+                .content(issue.getContent())
+                .createdAt(issue.getCreatedAt())
+                .isClose(issue.getIsClosed())
+                .build();
+    }
+}

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/dto/IssueUserResponseDto.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/dto/IssueUserResponseDto.java
@@ -1,0 +1,27 @@
+package codesquad.issueTracker.issue.dto;
+
+import codesquad.issueTracker.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class IssueUserResponseDto {
+    private Long id;
+    private String name;
+    private String imageUrl;
+
+    @Builder
+    public IssueUserResponseDto(Long id, String name, String imageUrl) {
+        this.id = id;
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
+
+    public static IssueUserResponseDto from(User user) {
+        return IssueUserResponseDto.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .imageUrl(user.getProfileImg())
+                .build();
+    }
+}

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/repository/IssueRepository.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/repository/IssueRepository.java
@@ -1,6 +1,10 @@
 package codesquad.issueTracker.issue.repository;
 
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.dao.support.DataAccessUtils;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
@@ -48,5 +52,27 @@ public class IssueRepository {
 			.addValue("userId", userId);
 		jdbcTemplate.update(sql, parameters, keyHolder);
 		return keyHolder.getKey().longValue();
+	}
+
+	public Optional<Issue> findActiveIssueById(Long issueId) {
+		String sql = "SELECT * FROM issues WHERE id = :issueId AND is_deleted = false";
+		return Optional.ofNullable(
+				DataAccessUtils.singleResult(
+						jdbcTemplate.query(sql, Map.of("issueId", issueId), issueRowMapper)));
+	}
+
+	private final RowMapper<Issue> issueRowMapper = ((rs, rowNum) -> Issue.builder()
+			.id(rs.getLong("id"))
+			.title(rs.getString("title"))
+			.content(rs.getString("content"))
+			.createdAt(rs.getTimestamp("created_at").toLocalDateTime())
+			.isClosed(rs.isClosed())
+			.build());
+
+	public Optional<Issue> findById(Long issueId) {
+		String sql = "SELECT * FROM issues WHERE id = :issueId";
+		return Optional.ofNullable(
+				DataAccessUtils.singleResult(
+						jdbcTemplate.query(sql, Map.of("issueId", issueId), issueRowMapper)));
 	}
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/service/IssueService.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/service/IssueService.java
@@ -1,7 +1,7 @@
 package codesquad.issueTracker.issue.service;
 
 import codesquad.issueTracker.global.common.Status;
-import codesquad.issueTracker.issue.controller.IssueOptionResponseDto;
+import codesquad.issueTracker.issue.dto.IssueOptionResponseDto;
 import codesquad.issueTracker.issue.dto.IssueLabelResponseDto;
 import codesquad.issueTracker.issue.dto.IssueMilestoneResponseDto;
 import codesquad.issueTracker.issue.vo.IssueLabelVo;

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/service/IssueService.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/service/IssueService.java
@@ -1,7 +1,10 @@
 package codesquad.issueTracker.issue.service;
 
+import codesquad.issueTracker.global.common.Status;
 import codesquad.issueTracker.issue.dto.IssueLabelResponseDto;
+import codesquad.issueTracker.issue.dto.IssueMilestoneResponseDto;
 import codesquad.issueTracker.label.dto.LabelResponseDto;
+import codesquad.issueTracker.milestone.vo.MilestoneVo;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -73,6 +76,13 @@ public class IssueService {
 		LabelResponseDto allLabels = labelService.findAll();
 		return allLabels.getLabels().stream()
 				.map(IssueLabelResponseDto::from)
+				.collect(Collectors.toList());
+	}
+
+	public List<IssueMilestoneResponseDto> getIssueMilestones() {
+		List<MilestoneVo> milestones = milestoneService.findMilestonesByStatus(Status.OPEN.getStatus());
+		return milestones.stream()
+				.map(IssueMilestoneResponseDto::from)
 				.collect(Collectors.toList());
 	}
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/service/IssueService.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/service/IssueService.java
@@ -3,8 +3,10 @@ package codesquad.issueTracker.issue.service;
 import codesquad.issueTracker.global.common.Status;
 import codesquad.issueTracker.issue.dto.IssueLabelResponseDto;
 import codesquad.issueTracker.issue.dto.IssueMilestoneResponseDto;
+import codesquad.issueTracker.issue.dto.IssueUserResponseDto;
 import codesquad.issueTracker.label.dto.LabelResponseDto;
 import codesquad.issueTracker.milestone.vo.MilestoneVo;
+import codesquad.issueTracker.user.domain.User;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -83,6 +85,13 @@ public class IssueService {
 		List<MilestoneVo> milestones = milestoneService.findMilestonesByStatus(Status.OPEN.getStatus());
 		return milestones.stream()
 				.map(IssueMilestoneResponseDto::from)
+				.collect(Collectors.toList());
+	}
+
+	public List<IssueUserResponseDto> getIssueUsers() {
+		List<User> users = userService.getUsers();
+		return users.stream()
+				.map(IssueUserResponseDto::from)
 				.collect(Collectors.toList());
 	}
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/service/IssueService.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/service/IssueService.java
@@ -1,5 +1,7 @@
 package codesquad.issueTracker.issue.service;
 
+import codesquad.issueTracker.issue.dto.IssueLabelResponseDto;
+import codesquad.issueTracker.label.dto.LabelResponseDto;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -65,5 +67,12 @@ public class IssueService {
 				throw new CustomException(ErrorCode.DUPLICATE_OBJECT_FOUND);
 			}
 		}
+	}
+
+	public List<IssueLabelResponseDto> getIssueLabels() {
+		LabelResponseDto allLabels = labelService.findAll();
+		return allLabels.getLabels().stream()
+				.map(IssueLabelResponseDto::from)
+				.collect(Collectors.toList());
 	}
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/service/IssueService.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/service/IssueService.java
@@ -3,6 +3,7 @@ package codesquad.issueTracker.issue.service;
 import codesquad.issueTracker.global.common.Status;
 import codesquad.issueTracker.issue.dto.IssueLabelResponseDto;
 import codesquad.issueTracker.issue.dto.IssueMilestoneResponseDto;
+import codesquad.issueTracker.issue.dto.IssueResponseDto;
 import codesquad.issueTracker.issue.dto.IssueUserResponseDto;
 import codesquad.issueTracker.label.dto.LabelResponseDto;
 import codesquad.issueTracker.milestone.vo.MilestoneVo;
@@ -93,5 +94,17 @@ public class IssueService {
 		return users.stream()
 				.map(IssueUserResponseDto::from)
 				.collect(Collectors.toList());
+	}
+
+	public IssueResponseDto getIssueById(Long issueId) {
+		validateExistIssue(issueId);
+		Issue issue = issueRepository.findActiveIssueById(issueId)
+				.orElseThrow(() -> new CustomException(ErrorCode.ALREADY_DELETED_ISSUE));
+		return IssueResponseDto.from(issue);
+	}
+
+	private void validateExistIssue(Long issueId) {
+		issueRepository.findById(issueId)
+				.orElseThrow(() -> new CustomException(ErrorCode.NOT_EXIST_ISSUE));
 	}
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/vo/AssigneeVo.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/vo/AssigneeVo.java
@@ -1,0 +1,18 @@
+package codesquad.issueTracker.issue.vo;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AssigneeVo {
+    private Long id;
+    private String name;
+    private String imgUrl;
+
+    @Builder
+    public AssigneeVo(Long id, String name, String imgUrl) {
+        this.id = id;
+        this.name = name;
+        this.imgUrl = imgUrl;
+    }
+}

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/vo/IssueLabelVo.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/vo/IssueLabelVo.java
@@ -1,0 +1,31 @@
+package codesquad.issueTracker.issue.vo;
+
+import codesquad.issueTracker.label.domain.Label;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class IssueLabelVo {
+
+    private Long id;
+    private String name;
+    private String backgroundColor;
+    private String textColor;
+
+    @Builder
+    public IssueLabelVo(Long id, String name, String backgroundColor, String textColor) {
+        this.id = id;
+        this.name = name;
+        this.backgroundColor = backgroundColor;
+        this.textColor = textColor;
+    }
+
+    public static IssueLabelVo from(Label label) {
+        return IssueLabelVo.builder()
+                .id(label.getId())
+                .name(label.getName())
+                .backgroundColor(label.getBackgroundColor())
+                .textColor(label.getTextColor())
+                .build();
+    }
+}

--- a/be/issue/src/main/java/codesquad/issueTracker/issue/vo/IssueMilestoneVo.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/issue/vo/IssueMilestoneVo.java
@@ -1,0 +1,37 @@
+package codesquad.issueTracker.issue.vo;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class IssueMilestoneVo {
+    private Long id;
+    private String name;
+    private int completedRatio;
+
+    @Builder
+    public IssueMilestoneVo(Long id, String name, int completedRatio) {
+        this.id = id;
+        this.name = name;
+        this.completedRatio = completedRatio;
+    }
+
+    public static IssueMilestoneVo from(IssueMilestoneVo issueMilestone) {
+        return IssueMilestoneVo.builder()
+                .id(issueMilestone.getId())
+                .name(issueMilestone.getName())
+                .build();
+    }
+
+    public IssueMilestoneVo getMilestoneWithRatio(int openCount, int closeCount) {
+        return IssueMilestoneVo.builder()
+                .id(this.id)
+                .name(this.name)
+                .completedRatio(calculateRatio(openCount, closeCount))
+                .build();
+    }
+
+    private int calculateRatio(int openCount, int closeCount) {
+        return closeCount * 100 / (openCount + closeCount) ;
+    }
+}

--- a/be/issue/src/main/java/codesquad/issueTracker/label/repository/LabelRepository.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/label/repository/LabelRepository.java
@@ -96,4 +96,16 @@ public class LabelRepository {
 		.backgroundColor(rs.getString("background_color"))
 		.description(rs.getString("description"))
 		.build();
+
+	public List<Label> findLabelsById(Long issueId) {
+		String sql = "select l.id, l.name, l.background_color, l.text_color, l.description "
+				+ "from issues_labels il "
+				+ "    join issues i on i.id = il.issue_id "
+				+ "    join labels l on il.label_id = l.id "
+				+ "where i.id = :issueId "
+				+ "AND l.is_deleted = false "
+				+ "AND i.is_deleted = false ";
+		return jdbcTemplate.query(sql, Map.of("issueId", issueId), labelRowMapper);
+	}
+
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/label/service/LabelService.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/label/service/LabelService.java
@@ -1,8 +1,10 @@
 package codesquad.issueTracker.label.service;
 
+import codesquad.issueTracker.issue.vo.IssueLabelVo;
 import java.util.ArrayList;
 import java.util.List;
 
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 import codesquad.issueTracker.global.exception.CustomException;
@@ -47,5 +49,11 @@ public class LabelService {
 		for (Long label : labels) {
 			labelRepository.findById(label).orElseThrow(() -> new CustomException(ErrorCode.LABEL_FIND_FAILED));
 		}
+	}
+
+	public List<IssueLabelVo> findByIssueId(Long issueId) {
+		return labelRepository.findLabelsById(issueId).stream()
+				.map(IssueLabelVo::from)
+				.collect(Collectors.toList());
 	}
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/label/vo/LabelVo.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/label/vo/LabelVo.java
@@ -1,6 +1,7 @@
 package codesquad.issueTracker.label.vo;
 
 import codesquad.issueTracker.label.domain.Label;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -11,6 +12,7 @@ public class LabelVo {
 	private final String backgroundColor;
 	private final String description;
 
+	@Builder
 	public LabelVo(Long id, String name, String textColor, String backgroundColor, String description) {
 		this.id = id;
 		this.name = name;

--- a/be/issue/src/main/java/codesquad/issueTracker/milestone/repository/MilestoneRepository.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/milestone/repository/MilestoneRepository.java
@@ -1,8 +1,12 @@
 package codesquad.issueTracker.milestone.repository;
 
+import codesquad.issueTracker.issue.vo.IssueMilestoneVo;
 import java.time.LocalDate;
 import java.util.List;
 
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.dao.support.DataAccessUtils;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -106,4 +110,21 @@ public class MilestoneRepository {
 		.issueClosedCount(rs.getInt("issueClosedCount"))
 		.build();
 
+	public Optional<IssueMilestoneVo> findByIssueId(Long issueId) {
+		String sql = "select m.id, m.name "
+				+ "from milestones m "
+				+ "    join issues i on m.id = i.milestone_id "
+				+ "where i.id = :issueId "
+				+ "and i.is_deleted = false "
+				+ "and m.is_deleted = false";
+
+		return Optional.ofNullable(
+				DataAccessUtils.singleResult(
+						jdbcTemplate.query(sql, Map.of("issueId", issueId), issueMilestoneVoRowMapper)));
+	}
+
+	private final RowMapper<IssueMilestoneVo> issueMilestoneVoRowMapper = ((rs, rowNum) -> IssueMilestoneVo.builder()
+			.id(rs.getLong("id"))
+			.name(rs.getString("name"))
+			.build());
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/milestone/service/MilestoneService.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/milestone/service/MilestoneService.java
@@ -1,7 +1,10 @@
 package codesquad.issueTracker.milestone.service;
 
+import codesquad.issueTracker.issue.vo.IssueMilestoneVo;
 import java.util.List;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +23,9 @@ import lombok.RequiredArgsConstructor;
 @Service
 @Transactional(readOnly = true)
 public class MilestoneService {
+
+	private final Log log = LogFactory.getLog(MilestoneService.class);
+
 	private final MilestoneRepository milestoneRepository;
 
 	@Transactional
@@ -73,5 +79,10 @@ public class MilestoneService {
 
 	public List<MilestoneVo> findMilestonesByStatus(Boolean status) {
 		return milestoneRepository.findAll(status);
+	}
+
+	public IssueMilestoneVo findByIssueId(Long issueId) {
+		return milestoneRepository.findByIssueId(issueId)
+				.orElseGet(() -> IssueMilestoneVo.builder().build());
 	}
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/milestone/service/MilestoneService.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/milestone/service/MilestoneService.java
@@ -71,4 +71,7 @@ public class MilestoneService {
 		}
 	}
 
+	public List<MilestoneVo> findMilestonesByStatus(Boolean status) {
+		return milestoneRepository.findAll(status);
+	}
 }

--- a/be/issue/src/main/java/codesquad/issueTracker/milestone/service/MilestoneService.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/milestone/service/MilestoneService.java
@@ -58,7 +58,7 @@ public class MilestoneService {
 
 	public MilestoneResponseDto findAll(MileStoneStatusDto request) {
 		Boolean status = Status.from(request.getStatus()).getStatus();
-		List<MilestoneVo> milestones = milestoneRepository.findAll(status);
+		List<MilestoneVo> milestones = findMilestonesByStatus(status);
 		int labelCount = milestoneRepository.getLabelCount();
 		int anotherCount = milestoneRepository.getAnotherCount(!status);
 		MilestoneResponseDto milestoneResponseDto = new MilestoneResponseDto(labelCount, anotherCount, milestones);

--- a/be/issue/src/main/java/codesquad/issueTracker/user/repository/UserRepository.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package codesquad.issueTracker.user.repository;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -115,5 +116,9 @@ public class UserRepository {
 				jdbcTemplate.query(sql, Map.of("id", id), userRowMapper)));
 	}
 
+	public List<User> findAll() {
+		String sql = "SELECT * FROM users";
+		return jdbcTemplate.query(sql, userRowMapper);
+	}
 }
 

--- a/be/issue/src/main/java/codesquad/issueTracker/user/service/UserService.java
+++ b/be/issue/src/main/java/codesquad/issueTracker/user/service/UserService.java
@@ -110,4 +110,8 @@ public class UserService {
 
 	}
 
+	@Transactional(readOnly = true)
+	public List<User> getUsers() {
+		return userRepository.findAll();
+	}
 }


### PR DESCRIPTION
## What is this PR? 👓
- [x] 이슈 라벨 목록 조회 API 구현
- [x] 이슈 마일스톤 목록 조회 API 구현
- [x] 이슈 참여자 목록 조회 API 구현
- [x] 이슈 상세 조회 API 구현
- [x] 이유 상세 옵션 조회 API 구현

## To reviewers 👋
클래스 분리하려고 노력했는데 뭔가 더 복잡해진 느낌이에요.    
이슈 상세 옵션 조회에서 마일스톤이 존재하는 경우 레포지토리에 다섯 번 접근하는데 괜찮을지 잘 모르겠습니다.